### PR TITLE
added child class to use more card storage

### DIFF
--- a/examples/dump.py
+++ b/examples/dump.py
@@ -1,3 +1,4 @@
+from time import sleep
 from mfrc522 import StoreMFRC522
 key = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
 
@@ -33,6 +34,7 @@ def main():
             # Disconnect
             base_rc522.mfrc522_stop_crypto1()
 
+        sleep(1)
 
 
 if __name__ == '__main__':

--- a/examples/dump.py
+++ b/examples/dump.py
@@ -1,0 +1,40 @@
+from mfrc522 import StoreMFRC522
+key = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+
+
+def main():
+    reader = StoreMFRC522()
+    base_rc522 = reader.reader  # Lower-level access
+    print("Hold a tag near the reader")
+
+    while True:
+
+        # Scan for cards
+        status, tag = base_rc522.mfrc522_request(base_rc522.PICC_REQIDL)
+
+        # If a card is found
+        if status == base_rc522.MI_OK:
+            print("Card detected")
+
+
+        # Get the UID of the card
+        status, uid = base_rc522.mfrc522_anticoll()
+
+        # If we have the UID, continue
+        if status == base_rc522.MI_OK:
+            print(f"Card read UID: {uid}")
+
+            # Select the scanned tag
+            base_rc522.mfrc522_select_tag(uid)
+
+            # Dump tag content
+            base_rc522.mfrc522_dump_classic_1K(key, uid)
+
+            # Disconnect
+            base_rc522.mfrc522_stop_crypto1()
+
+
+
+if __name__ == '__main__':
+    main()
+

--- a/examples/read.py
+++ b/examples/read.py
@@ -1,0 +1,15 @@
+from time import sleep
+from mfrc522 import StoreMFRC522
+
+
+def main():
+    reader = StoreMFRC522()
+    while True:
+        print("Hold a tag near the reader")
+        tag_id, text = reader.read()
+        print(f'ID: {tag_id}\nText: {text}')
+        sleep(1)
+
+if __name__ == '__main__':
+    main()
+

--- a/examples/read_5blocks.py
+++ b/examples/read_5blocks.py
@@ -1,0 +1,24 @@
+from time import sleep
+from mfrc522 import StoreMFRC522
+
+
+def main():
+    reader = StoreMFRC522()
+    reader.BLOCK_ADDRESSES = {  # Only read 5 blocks
+             7: [ 4,  5,  6],
+            11: [ 8,  9, 10],
+            15: [12, 13, 14],
+            19: [16, 17, 18],
+            23: [20, 21, 22],
+        }
+    reader.BLOCK_SLOTS = sum(len(lst) for lst in reader.BLOCK_ADDRESSES.values())
+
+    while True:
+        print("Hold a tag near the reader")
+        tag_id, text = reader.read()
+        print(f'ID: {tag_id}\nText: {text}')
+        sleep(1)
+
+if __name__ == '__main__':
+    main()
+

--- a/examples/write.py
+++ b/examples/write.py
@@ -1,0 +1,16 @@
+from time import sleep
+from mfrc522 import StoreMFRC522
+
+
+def main():
+    reader = StoreMFRC522()
+    text: str = input('Text to write to your tag: ')
+    while True:
+        print("Hold a tag near the reader")
+        tag_id, text = reader.write(text)
+        print(f'ID: {tag_id}\nText: {text}')
+        sleep(1)
+
+if __name__ == '__main__':
+    main()
+

--- a/mfrc522/MFRC522.py
+++ b/mfrc522/MFRC522.py
@@ -324,3 +324,18 @@ class MFRC522:
         self.write_mfrc522(self.TX_AUTO_REG, 0x40)
         self.write_mfrc522(self.MODE_REG, 0x3D)
         self.antenna_on()
+
+    def mfrc522_dump_classic_1K(self, key, uid):
+        i = 0
+        while i < 64:
+            status = self.mfrc522_auth(self.PICC_AUTHENT1A, i, key, uid)
+            # Check if authenticated
+            if status == self.MI_OK:
+                data = self.mfrc522_read(i)
+                print(f"Sector {i}: {data}")
+
+            else:
+                print("Authentication error")
+            i = i+1
+
+

--- a/mfrc522/SimpleMFRC522.py
+++ b/mfrc522/SimpleMFRC522.py
@@ -182,7 +182,7 @@ class StoreMFRC522(SimpleMFRC522):
 
 
     def write_password_to_blocks(self, password):
-#       raise NotImplementedError("Seems to brick the RFID tag, but maybe I dont know how to read it.")
+        raise NotImplementedError("Seems to brick the RFID tag, but maybe I dont know how to read it.")
         """
         Write a 6-byte password key as both Key A and Key B plus access bits
         into sector trailer blocks in self.BLOCK_ADDRESSES.keys().

--- a/mfrc522/SimpleMFRC522.py
+++ b/mfrc522/SimpleMFRC522.py
@@ -78,7 +78,7 @@ class SimpleMFRC522:
             self.reader.PICC_AUTHENT1A, 11, self.KEYS, uid
         )
         self.reader.mfrc522_read(11)
-        if status =I self.reader.MI_OK:
+        if status == self.reader.MI_OK:
             data = bytearray()
             data.extend(
                 bytearray(text.ljust(len(self.BLOCK_ADDRESSES) * 16).encode("ascii"))
@@ -195,7 +195,7 @@ class StoreMFRC522(SimpleMFRC522):
         access_bits = [0xFF, 0x07, 0x80, 0x69]
         trailer_data = bytes(password + access_bits + password)
         if password = [0, 0, 0, 0, 0, 0]:  # Set default password
-            trailer_data = bytes(password + access_bits + self.KEYS)
+            trailer_data = bytes(password + access_bits + [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
 
         for block in self.BLOCK_ADDRESSES.keys():
             # Wait for card presence

--- a/mfrc522/SimpleMFRC522.py
+++ b/mfrc522/SimpleMFRC522.py
@@ -7,6 +7,8 @@ Adopted from https://github.com/Dennis-89/MFRC522-python-SimpleMFRC522.git
 from . import MFRC522
 from itertools import chain
 
+DEFAULT_KEYS = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+
 
 class SimpleMFRC522:
     KEYS = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
@@ -165,7 +167,7 @@ class StoreMFRC522(SimpleMFRC522):
         data.extend(
             bytearray(text.ljust(self.BLOCK_SLOTS * 16).encode("ascii"))
         )
-        slot_i = 0
+        slot_i: int = 0
         for trailer_block in self.BLOCK_ADDRESSES.keys():
             status = self.reader.mfrc522_auth(
                 self.reader.PICC_AUTHENT1A, trailer_block, self.KEYS, uid
@@ -180,10 +182,11 @@ class StoreMFRC522(SimpleMFRC522):
         self.reader.mfrc522_stop_crypto1()
         return tag_id, text[: len(self.BLOCK_ADDRESSES) * 16]
 
-
     def write_password_to_blocks(self, password):
-#       raise NotImplementedError("Seems to brick the RFID tag, but maybe I dont know how to read it.")
+        raise NotImplementedError("Seems to brick the RFID tag, needs more work (and more tags to bricks..).")
         """
+        Ideas for future - set keys A and B independently by different methods; keep the other code default for testing.   
+        
         Write a 6-byte password key as both Key A and Key B plus access bits
         into sector trailer blocks in self.BLOCK_ADDRESSES.keys().
 
@@ -194,8 +197,8 @@ class StoreMFRC522(SimpleMFRC522):
             raise ValueError("Password must be a list of 6 integers (0-255)")
 
         access_bits = [0xFF, 0x07, 0x80, 0x69]
-        if password == [0, 0, 0, 0, 0, 0] or password == [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]:  # Set default password
-            password = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
+        if password == [0, 0, 0, 0, 0, 0] or password == DEFAULT_KEYS:  # Set default password
+            password = DEFAULT_KEYS
         trailer_data = bytes(password + access_bits + password)
         print(f'writing password: {password}')
 
@@ -211,7 +214,7 @@ class StoreMFRC522(SimpleMFRC522):
             if status == self.reader.MI_OK:
                 break
 
-        # Set
+        # Set all trailing sectors
         trailer_blocks = [3]
         trailer_blocks.extend(self.BLOCK_ADDRESSES.keys())
         for block in trailer_blocks:
@@ -223,7 +226,7 @@ class StoreMFRC522(SimpleMFRC522):
             if status != self.reader.MI_OK:
                 raise RuntimeError(f"Authentication failed for block {block}")
             else:
-                print(f'Autheticated card {uid}')
+                print(f'Authenticated card {uid}')
 
             self.reader.mfrc522_read(block)
             if status == self.reader.MI_OK:
@@ -236,4 +239,3 @@ class StoreMFRC522(SimpleMFRC522):
 
             # Stop encryption on the card
             self.reader.mfrc522_stop_crypto1()
-

--- a/mfrc522/SimpleMFRC522.py
+++ b/mfrc522/SimpleMFRC522.py
@@ -195,7 +195,7 @@ class StoreMFRC522(SimpleMFRC522):
 
         access_bits = [0xFF, 0x07, 0x80, 0x69]
         if password == [0, 0, 0, 0, 0, 0] or password == [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]:  # Set default password
-            password = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
+            password = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
         trailer_data = bytes(password + access_bits + password)
         print(f'writing password: {password}')
 

--- a/mfrc522/SimpleMFRC522.py
+++ b/mfrc522/SimpleMFRC522.py
@@ -78,7 +78,7 @@ class SimpleMFRC522:
             self.reader.PICC_AUTHENT1A, 11, self.KEYS, uid
         )
         self.reader.mfrc522_read(11)
-        if status == self.reader.MI_OK:
+        if status =I self.reader.MI_OK:
             data = bytearray()
             data.extend(
                 bytearray(text.ljust(len(self.BLOCK_ADDRESSES) * 16).encode("ascii"))
@@ -200,29 +200,29 @@ class StoreMFRC522(SimpleMFRC522):
         for block in self.BLOCK_ADDRESSES.keys():
             # Wait for card presence
             while True:
-                status, _ = self.reader.mfrc522_request(self.reader.picc_reqidl)
-                if status == self.reader.mi_ok:
+                status, _ = self.reader.mfrc522_request(self.reader.PICC_REQIDL)
+                if status == self.reader.MI_OK:
                     break
 
             # Get UID through anti-collision
             while True:
                 status, uid = self.reader.mfrc522_anticoll()
-                if status == self.reader.mi_ok:
+                if status == self.reader.MI_OK:
                     break
 
             # Select the tag
             self.reader.mfrc522_selecttag(uid)
 
             # Authenticate with current key (self.KEY)
-            status = self.reader.mfrc522_auth(self.reader.picc_authent1a, block, self.KEY, uid)
-            if status != self.reader.mi_ok:
+            status = self.reader.mfrc522_auth(self.reader.PICC_AUTHENT1A, block, self.KEY, uid)
+            if status != self.reader.MI_OK:
                 raise RuntimeError(f"Authentication failed for block {block}")
 
             # Write the sector trailer block
             status = self.reader.mfrc522_write(block, trailer_data)
-            if status != self.reader.mi_ok:
+            if status != self.reader.MI_OK:
                 raise RuntimeError(f"Write failed for block {block}")
 
             # Stop encryption on the card
-            self.reader.mfrc522_stopcrypto1()
+            self.reader.mfrc522_stop_crypto1()
 

--- a/mfrc522/__init__.py
+++ b/mfrc522/__init__.py
@@ -1,4 +1,5 @@
 from .MFRC522 import MFRC522
 from .SimpleMFRC522 import SimpleMFRC522
+from .SimpleMFRC522 import StoreMFRC522
 
 name = "mfrc522"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def main():
 
     setuptools.setup(
         name="mfrc522",
-        version="1.0.0",
+        version="1.0.1",
         author="Pi My Life Up / Dennis89",
         author_email="straub.dennis1@web.de",
         description="A library to integrate the MFRC522 RFID readers with the Raspberry Pi",


### PR DESCRIPTION
The new class reads and writes 45 sectors (720 bytes), while the original one only used 3 sectors (48 bytes).

## Summary by Sourcery

Introduce StoreMFRC522 subclass to extend RFID card storage from 3 to 45 sectors, update version and export the new class

New Features:
- Add StoreMFRC522 subclass that reads and writes up to 45 sectors (720 bytes) on RFID cards

Build:
- Bump package version from 1.0.0 to 1.0.1

Chores:
- Expose StoreMFRC522 in the module's public API